### PR TITLE
Enhance page style with animated plane

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,13 +92,12 @@
 </table>
 <hr class="soft">
 <!--Internships-->
-<button style="font-size:xx-large; border: 0; background-color: transparent; outline: none; font-weight: 700; color: #d38975; font-family: 'Nunito', sans-serif;" 
-        type="button" 
-        class="collapsible" 
-        data-toggle="collapse" 
-        data-target="#content-internships" 
+<button type="button"
+        class="collapsible"
+        data-toggle="collapse"
+        data-target="#content-internships"
         id="internships">
-    ✈️ Experience
+    <span class="fly-plane">✈️</span> Experience
 </button>
 
 <!-- <button style="border:0px; background-color: transparent; outline:none; font-weight: bolder; color: #f04719;;" type="button" class="collapsible" data-toggle="collapse" data-target="#content-internships" id="internships"><heading>✈️ Experience</heading></button> -->

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -130,3 +130,36 @@ name {
 span.highlight {
   background-color: #ffffd0;
 }
+
+/* Background color for the main page */
+.bg_colour {
+  background-color: #fdfdfd;
+}
+
+/* Style for collapsible section headers */
+button.collapsible {
+  font-size: 24px;
+  font-weight: 700;
+  color: #d38975;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-family: 'Nunito', sans-serif;
+  margin: 15px 0;
+}
+
+button.collapsible:hover {
+  color: #f09228;
+}
+
+/* Animated airplane next to Experience */
+.fly-plane {
+  display: inline-block;
+  animation: plane-fly 2s ease-in-out infinite;
+}
+
+@keyframes plane-fly {
+  0% { transform: translateX(0); }
+  50% { transform: translateX(8px); }
+  100% { transform: translateX(0); }
+}


### PR DESCRIPTION
## Summary
- animate the ✈️ icon next to the Experience button
- refactor Experience button markup
- add styling for collapsible headers and page background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687b2d3084f883308cad168eed656c37